### PR TITLE
Adding type_extra variable to prodstatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,69 @@
 # puppet-module-production-status
 Classification of a server in what production status it is.
+
+
+# Parameters prodstatus
+
+allowed_states
+--------------
+An array of allowed states for a server. To force people to write accroding to a set standard
+
+- *Default*: allowed_states = {
+    pre_prod ['Installing', 'PoC', 'Sandbox'],
+    prod     ['In Production'],
+    decom    ['Decomissioned'] }
+
+allowed_server_types
+--------------
+An array of allowed server types. To force people to write accroding to a set standard
+
+- *Default*: ['Infrastructure']
+
+state
+-----
+The current state your server is in.
+
+- *Default*: 'Installing'
+
+type
+----
+What function does your server fil?
+
+- *Default*: 'Infrastructure'
+
+file_path
+---------
+The location of the prodstatus files. Do not change this location since it will destory the fact generation.
+
+- *Default*: '/etc/prodstatus'
+
+type_extra
+--------------
+An extra way of definnig what the type fact should be called.
+This is only for handeling a specific case where i have to be able to 
+call this module something else then production_type.
+
+- *Default*: undef
+
+fact_location
+--------------
+Path for pointing out the location for facts.
+This module don't handle the creating of this path.
+
+- *Default*: '/etc/facter/facts.d'
+
+hiera_example
+-------------
+prodstatus::allowed_server_types:
+  - 'Infrastructure'
+  - 'Customerserver'
+  - 'Terminal'
+prodstatus::allowed_states:
+  pre_prod:
+    - 'Installing'
+    - 'PoC'
+    - 'Sandbox'
+  prod:
+    - 'In Production'
+  decom:
+    - 'Decomissioned'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,8 @@ class prodstatus (
   $state                = 'Installing',
   $type                 = 'Infrastructure',
   $file_path            = '/etc/prodstatus', # Changing this will break the facts.
+  $type_extra           = undef,
+  $fact_location        = '/etc/facter/facts.d', # Default in puppet, other modules handle this path.
 ) {
   if $ensure == 'present' {
 
@@ -68,6 +70,17 @@ class prodstatus (
       match => '^Production type:',
       line  => "Production type: ${type}",
     }
+
+    if $type_extra {
+      file { 'second-type-fact':
+        ensure  => file,
+        path    => "${fact_location}/${type_extra}.txt",
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => "${type_extra}=${type}",
+      }
+    }
   }
   else {
     notify { "${type} is not a valid type!": }
@@ -78,7 +91,7 @@ class prodstatus (
      ensure => absent,
      path   => "${file_path}/state",
    }
-   file { 'production-type': 
+   file { 'production-type':
      ensure => absent,
      path   => "${file_path}/type",
    }
@@ -89,5 +102,9 @@ class prodstatus (
      match_for_absence => true,
      multiple          => true,
   }
+   file { 'second-type-fact':
+     ensure => absent,
+     path   => "${fact_location}/${type_extra}.txt",
+   }
  }
 }


### PR DESCRIPTION
Due to reasons we need to have the possabiliaty the call our type fact
a specific thing. Adding the type_extra to generate a second fact under
the default fact location.
At the same time i fil in some basic README info.